### PR TITLE
 Update to github.com/mashiike/canyon and add retry policy with jittered exponential backoff based on SQS ApproximateReceiveCount

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,21 @@ rule "always" {
 }
 ```
 
+## Local Development
+
+```shell
+$ PREPALERT_CANYON_ENV=development go run cmd/prepalert/main.go --config testdata/config/simple.hcl
+time=2023-10-01T14:55:47.267+09:00 level=INFO msg="create temporary file backend, canyon request body upload to temporary directory" path=/var/folders/rn/jj26k6s93x9c5yblnjq7_dw80000gp/T/canon-240945814 version=v0.12.0 app=prepalert
+time=2023-10-01T14:55:47.268+09:00 level=INFO msg="running canyon" env=development version=v0.12.0 app=prepalert
+time=2023-10-01T14:55:47.268+09:00 level=INFO msg="enable in memory queue" visibility_timeout=30s max_receive_count=3 version=v0.12.0 app=prepalert
+time=2023-10-01T14:55:47.268+09:00 level=INFO msg="starting up with local httpd" address=:8080 version=v0.12.0 app=prepalert
+time=2023-10-01T14:55:47.268+09:00 level=INFO msg="staring polling sqs queue" queue=prepalert on_memory_queue_mode=true version=v0.12.0 app=prepalert
+```
+
+prepalert is using [canyon](https://github.com/mashiike/canyon).
+if you want to use local development, you can use `PREPALERT_CANYON_ENV=development` environment variable.
+this variable is enable to use local file backend and sqs simulated in memory queue.
+
 ## LICENSE
 
 MIT License

--- a/app_test.go
+++ b/app_test.go
@@ -143,6 +143,7 @@ func TestAppLoadConfig__WithQuery(t *testing.T) {
 		"query.redshift_data.serverless_access_logs",
 	}, app.QueryList())
 	require.True(t, app.EnableBasicAuth())
+	require.Equal(t, "interval:10s jitter:30s max_interval:300s backoff_factor:4.00", app.RetryPolicy().String())
 	rules := app.Rules()
 	require.Len(t, rules, 2)
 	require.ElementsMatch(t, []string{

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/kayac/go-katsubushi v1.7.0
 	github.com/mackerelio/mackerel-client-go v0.26.0
 	github.com/manifoldco/promptui v0.9.0
-	github.com/mashiike/canyon v0.5.0
+	github.com/mashiike/canyon v0.6.0
 	github.com/mashiike/cloudwatch-logs-insights-driver v0.1.5
 	github.com/mashiike/hclutil v0.5.3
 	github.com/mashiike/ls3viewer v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,6 @@ github.com/aws/aws-sdk-go-v2/credentials v1.13.40 h1:s8yOkDh+5b1jUDhMBtngF6zKWLD
 github.com/aws/aws-sdk-go-v2/credentials v1.13.40/go.mod h1:VtEHVAAqDWASwdOqj/1huyT6uHbs5s8FUHfDQdky/Rs=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.11 h1:uDZJF1hu0EVT/4bogChk8DyjSF6fof6uL/0Y26Ma7Fg=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.11/go.mod h1:TEPP4tENqBGO99KwVpV9MlOX4NSrSLP8u3KRy2CDwA8=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.86 h1:tnn/U5bz5flqoTCFSgRMEdg93ULR9Q6+tL5LkwjJ0DM=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.86/go.mod h1:TJGNZIhz3fsaQ6PU9roZacAEMMnG89X2UzaDblNoeNw=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.87 h1:e20ZrsgDPUXqg8+rZVuPwNSp6yniUN2Yr2tzFZ+Yvl0=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.87/go.mod h1:0i0TAT6W+5i48QTlDU2KmY6U2hBZeY/LCP0wktya2oc=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.25/go.mod h1:Zb29PYkf42vVYQY6pvSyJCJcFHlPIiY+YKdPtwnvMkY=
@@ -59,8 +57,6 @@ github.com/aws/aws-sdk-go-v2/service/lambda v1.39.5 h1:uMvxJFS92hNW6BRX0Ou+5zb9D
 github.com/aws/aws-sdk-go-v2/service/lambda v1.39.5/go.mod h1:ByLHcf0zbHpyLTOy1iPVRPJWmAUPCiJv5k81dt52ID8=
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.16.13 h1:hVrup9EZ/QgcSn6viaHnNTGvr+F82fUekDrvmtoKIPQ=
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.16.13/go.mod h1:7f6XcpJ1hH7ai5yby7gE03CaIXqGvlaWGilNnE/wzpc=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.39.0 h1:VZ2WMkKLio5tVjYfThcy5+pb6YHGd6B6egq75FfM6hU=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.39.0/go.mod h1:rDGMZA7f4pbmTtPOk5v5UM2lmX6UAbRnMDJeDvnH7AM=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.40.0 h1:wl5dxN1NONhTDQD9uaEvNsDRX29cBmGED/nl0jkWlt4=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.40.0/go.mod h1:rDGMZA7f4pbmTtPOk5v5UM2lmX6UAbRnMDJeDvnH7AM=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.3.0 h1:uzCEL2ILopsOcWvbmeMmmy3Sc0ybVh+nHMg5knnA0Rg=
@@ -161,10 +157,8 @@ github.com/mackerelio/mackerel-client-go v0.26.0 h1:72hj2zw/rqTUNMNokenRxs6KfJ1a
 github.com/mackerelio/mackerel-client-go v0.26.0/go.mod h1:b4qVMQi+w4rxtKQIFycLWXNBtIi9d0r571RzYmg/aXo=
 github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
 github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
-github.com/mashiike/canyon v0.3.1 h1:9E2N7iHRaqTtnA/IinMTX82zdiE7iQ+U/sUNIlsyzxc=
-github.com/mashiike/canyon v0.3.1/go.mod h1:IUoJ+1JKccjn91shvmTU6cjpzz6Xx2fMpi0H24mYsPM=
-github.com/mashiike/canyon v0.5.0 h1:ON83RIIqsTGDsCs9TkV5ewiMGn3xSc0negAQdqrauAY=
-github.com/mashiike/canyon v0.5.0/go.mod h1:/f5XIr5wvN7R25oH/bZTtWHhzwPzl9LqftDQ2Ss87Yo=
+github.com/mashiike/canyon v0.6.0 h1:4gp18Gdb+VI0IpFBXBJuBDbn0hFmT/G+aAkpNZlVHTU=
+github.com/mashiike/canyon v0.6.0/go.mod h1:kZD3+GnbzbslzS9NQxy1xNGntsP7RP7w4MsZ/HfiB1c=
 github.com/mashiike/cloudwatch-logs-insights-driver v0.1.5 h1:Cr+0t85xfrwUsN1Oj8FrZuzFjwzQvPktsTxM+XNtGPU=
 github.com/mashiike/cloudwatch-logs-insights-driver v0.1.5/go.mod h1:M9Ugk0o4HcnH6zyd1VIiQFLjriqtQijvpsBhqPD4ico=
 github.com/mashiike/hclutil v0.5.3 h1:L9DnRTTLyaGuiDrbyA1U/5XjuvUXKH+Kz393hBMepPA=

--- a/retry_poilcy.go
+++ b/retry_poilcy.go
@@ -1,0 +1,65 @@
+package prepalert
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"sync"
+
+	"github.com/Songmu/flextime"
+	"github.com/mashiike/canyon"
+)
+
+type RetryPolicy struct {
+	randGenerator *rand.Rand
+	once          sync.Once
+	Interval      float64 `hcl:"interval,optional"`
+	Jitter        float64 `hcl:"jitter,optional"`
+	MaxInterval   float64 `hcl:"max_interval,optional"`
+	BackoffFactor float64 `hcl:"backoff_factor,optional"`
+}
+
+func (rp *RetryPolicy) SetRetryAfter(w http.ResponseWriter, r *http.Request) {
+	if rp == nil {
+		return
+	}
+	if rp.Interval < 0 {
+		return
+	}
+	rp.once.Do(func() {
+		if rp.BackoffFactor == 0 {
+			rp.BackoffFactor = 2
+		}
+		if rp.Interval > rp.MaxInterval {
+			rp.Interval = rp.MaxInterval
+		}
+		rp.randGenerator = rand.New(rand.NewSource(flextime.Now().UnixNano()))
+	})
+	approxmateReceiveCount, err := strconv.Atoi(
+		r.Header.Get(canyon.HeaderSQSAttribute("ApproximateReceiveCount")),
+	)
+	if err != nil {
+		approxmateReceiveCount = 1
+	}
+	// exponential backoff
+	// base * factor ^ (approxmateReceiveCount - 1)
+	s := rp.Interval * math.Pow(rp.BackoffFactor, float64(approxmateReceiveCount-1))
+	if s > rp.MaxInterval {
+		s = rp.MaxInterval
+		s -= rp.randGenerator.Float64() * rp.Jitter
+	} else {
+		s += rp.randGenerator.Float64() * rp.Jitter
+	}
+	w.Header().Set("Retry-After", fmt.Sprintf("%d", int(s)))
+}
+
+func (rp *RetryPolicy) String() string {
+	if rp == nil {
+		return ""
+	}
+	return fmt.Sprintf(
+		"interval:%ds jitter:%ds max_interval:%ds backoff_factor:%.2f",
+		int(rp.Interval), int(rp.Jitter), int(rp.MaxInterval), rp.BackoffFactor)
+}

--- a/retry_policy_test.go
+++ b/retry_policy_test.go
@@ -1,0 +1,130 @@
+package prepalert_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/mashiike/canyon"
+	"github.com/mashiike/prepalert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryPolicySetRetryAfter__Nil(t *testing.T) {
+	t.Parallel()
+	var rp *prepalert.RetryPolicy
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	rp.SetRetryAfter(w, r)
+	require.Equal(t, "", w.Header().Get("Retry-After"))
+}
+
+func TestRetryPolicySetRetryAfter__IntervalLessThanZero(t *testing.T) {
+	t.Parallel()
+	rp := &prepalert.RetryPolicy{
+		Interval: -1,
+	}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	rp.SetRetryAfter(w, r)
+	require.Equal(t, "", w.Header().Get("Retry-After"))
+}
+
+func TestRetryPolicySetRetryAfter__First(t *testing.T) {
+	t.Parallel()
+	rp := &prepalert.RetryPolicy{
+		Interval:      5,
+		MaxInterval:   300,
+		BackoffFactor: 2,
+		Jitter:        0,
+	}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set(canyon.HeaderSQSAttribute("ApproximateReceiveCount"), "1")
+	rp.SetRetryAfter(w, r)
+	require.Equal(t, "5", w.Header().Get("Retry-After"))
+}
+
+func TestRetryPolicySetRetryAfter__Second(t *testing.T) {
+	t.Parallel()
+	rp := &prepalert.RetryPolicy{
+		Interval:      5,
+		MaxInterval:   300,
+		BackoffFactor: 2,
+		Jitter:        0,
+	}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set(canyon.HeaderSQSAttribute("ApproximateReceiveCount"), "2")
+	rp.SetRetryAfter(w, r)
+	require.Equal(t, "10", w.Header().Get("Retry-After"))
+}
+
+func TestRetryPolicySetRetryAfter__Third(t *testing.T) {
+	t.Parallel()
+	rp := &prepalert.RetryPolicy{
+		Interval:      5,
+		MaxInterval:   300,
+		BackoffFactor: 2,
+		Jitter:        0,
+	}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set(canyon.HeaderSQSAttribute("ApproximateReceiveCount"), "3")
+	rp.SetRetryAfter(w, r)
+	require.Equal(t, "20", w.Header().Get("Retry-After"))
+}
+
+func TestRetryPolicySetRetryAfter__MaxInterval(t *testing.T) {
+	t.Parallel()
+	rp := &prepalert.RetryPolicy{
+		Interval:      5,
+		MaxInterval:   300,
+		BackoffFactor: 2,
+		Jitter:        0,
+	}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set(canyon.HeaderSQSAttribute("ApproximateReceiveCount"), "100")
+	rp.SetRetryAfter(w, r)
+	require.Equal(t, "300", w.Header().Get("Retry-After"))
+}
+
+func TestRetryPolicySetRetryAfter__FirstWithJittr(t *testing.T) {
+	t.Parallel()
+	rp := &prepalert.RetryPolicy{
+		Interval:      5,
+		MaxInterval:   300,
+		BackoffFactor: 2,
+		Jitter:        15,
+	}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set(canyon.HeaderSQSAttribute("ApproximateReceiveCount"), "1")
+	rp.SetRetryAfter(w, r)
+	retryAfter, err := strconv.Atoi(w.Header().Get("Retry-After"))
+	require.NoError(t, err)
+	t.Log("Retry-After:", retryAfter)
+	require.GreaterOrEqual(t, retryAfter, 5)
+	require.LessOrEqual(t, retryAfter, 20)
+}
+
+func TestRetryPolicySetRetryAfter__MaxIntervalWithJittr(t *testing.T) {
+	t.Parallel()
+	rp := &prepalert.RetryPolicy{
+		Interval:      5,
+		MaxInterval:   300,
+		BackoffFactor: 2,
+		Jitter:        15,
+	}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set(canyon.HeaderSQSAttribute("ApproximateReceiveCount"), "100")
+	rp.SetRetryAfter(w, r)
+	retryAfter, err := strconv.Atoi(w.Header().Get("Retry-After"))
+	require.NoError(t, err)
+	t.Log("Retry-After:", retryAfter)
+	require.GreaterOrEqual(t, retryAfter, 285)
+	require.LessOrEqual(t, retryAfter, 300)
+}

--- a/testdata/config/with_query/config.hcl
+++ b/testdata/config/with_query/config.hcl
@@ -6,6 +6,14 @@ prepalert {
     client_id     = "hoge"
     client_secret = "fuga"
   }
+
+  retry {
+    interval       = duration("10s")
+    backoff_factor = 4
+    max_interval   = duration("5m")
+    jitter         = duration("30s")
+  }
+
 }
 
 provider "redshift_data" {


### PR DESCRIPTION
This PR updates the code to use the latest version of github.com/mashiike/canyon and adds a retry policy with jittered exponential backoff based on the SQS ApproximateReceiveCount. The retry policy allows setting the backoff time based on the number of times a message has been received. The maximum interval can be set, but the retry count is controlled by SQS and cannot be configured.

The `retry` block has been added to the `prepalert` block configuration with the following parameters:

```hcl
prepalert {
  required_version = ">=v0.12.0"
  sqs_queue_name   = "prepalert"

  retry {
    interval       = duration("10s")
    backoff_factor = 4
    max_interval   = duration("5m")
    jitter         = duration("30s")
  }
}
```

- interval: The initial interval between retries, set to 10 seconds.
- backoff_factor: The factor by which the retry interval increases with each retry, set to 4.
- max_interval: The maximum interval between retries, set to 5 minutes.
- jitter: The amount of jitter to add to the retry interval, set to 30 seconds.

1st recevie `10s ~ 40s`, 2nd recevie `40s ~ 70s`, 3rd receive `160s ~ 190s`, after `270s ~ 300s`